### PR TITLE
Add server-side validation for contact API

### DIFF
--- a/api/send.js
+++ b/api/send.js
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer';
+import validator from 'validator';
 
 export default async function handler(req, res) {
   // Only allow POST requests
@@ -9,9 +10,30 @@ export default async function handler(req, res) {
   try {
     const { name, email, organization, phone, message } = req.body || {};
 
-    // Validate required fields
-    if (!email || !message || !name) {
-      return res.status(400).json({ ok: false, error: 'Missing required fields' });
+    // Validate and sanitize inputs
+    if (!email || !validator.isEmail(email)) {
+      return res.status(400).json({ ok: false, error: 'Invalid email' });
+    }
+    if (!name || validator.isEmpty(name.trim())) {
+      return res.status(400).json({ ok: false, error: 'Invalid name' });
+    }
+    if (!message || validator.isEmpty(message.trim())) {
+      return res.status(400).json({ ok: false, error: 'Invalid message' });
+    }
+    if (phone && !validator.isMobilePhone(phone, 'any')) {
+      return res.status(400).json({ ok: false, error: 'Invalid phone' });
+    }
+
+    const normalizedEmail = validator.normalizeEmail(email);
+    const sanitizedEmail = validator.escape(normalizedEmail || email);
+    const sanitizedName = validator.escape(name.trim());
+    const sanitizedOrg = organization ? validator.escape(organization.trim()) : '';
+    const sanitizedPhone = phone ? validator.escape(phone.trim()) : '';
+    const sanitizedMessage = validator.escape(message.trim());
+
+    const recipient = process.env.TO_EMAIL;
+    if (!recipient) {
+      return res.status(500).json({ ok: false, error: 'Email recipient not configured' });
     }
 
     // Create Gmail transporter
@@ -23,22 +45,22 @@ export default async function handler(req, res) {
       }
     });
 
-    const subject = `New contact from ${name}${organization ? ' - ' + organization : ''}`;
+    const subject = `New contact from ${sanitizedName}${sanitizedOrg ? ' - ' + sanitizedOrg : ''}`;
     const html = `
       <div style="font-family:Inter,Arial,sans-serif;line-height:1.6;color:#0f172a;">
         <h2 style="margin:0 0 12px 0;">New Contact Request</h2>
-        <p><strong>Name:</strong> ${name}</p>
-        <p><strong>Email:</strong> ${email}</p>
-        <p><strong>Organization:</strong> ${organization || '-'}
-        <br/><strong>Phone:</strong> ${phone || '-'}</p>
-        <p style="white-space:pre-wrap"><strong>Message:</strong><br/>${message}</p>
+        <p><strong>Name:</strong> ${sanitizedName}</p>
+        <p><strong>Email:</strong> ${sanitizedEmail}</p>
+        <p><strong>Organization:</strong> ${sanitizedOrg || '-'}
+        <br/><strong>Phone:</strong> ${sanitizedPhone || '-'}</p>
+        <p style="white-space:pre-wrap"><strong>Message:</strong><br/>${sanitizedMessage}</p>
       </div>
     `;
 
     const mailOptions = {
       from: `MediFlow Website <${process.env.GMAIL_USER}>`,
-      to: process.env.TO_EMAIL || 'vitevabygenore@gmail.com',
-      replyTo: email,
+      to: recipient,
+      replyTo: sanitizedEmail,
       subject,
       html,
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
 				"react-helmet": "^6.1.0",
 				"react-router-dom": "^7.8.2",
 				"tailwind-merge": "^1.14.0",
-				"tailwindcss-animate": "^1.0.7"
+				"tailwindcss-animate": "^1.0.7",
+				"validator": "^13.15.15"
 			},
 			"devDependencies": {
 				"@vitejs/plugin-react": "^4.0.3",
@@ -2946,6 +2947,15 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"license": "MIT"
+		},
+		"node_modules/validator": {
+			"version": "13.15.15",
+			"resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+			"integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
 		},
 		"node_modules/vite": {
 			"version": "4.5.14",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
 		"react-helmet": "^6.1.0",
 		"react-router-dom": "^7.8.2",
 		"tailwind-merge": "^1.14.0",
-		"tailwindcss-animate": "^1.0.7"
+		"tailwindcss-animate": "^1.0.7",
+		"validator": "^13.15.15"
 	},
 	"devDependencies": {
 		"@vitejs/plugin-react": "^4.0.3",


### PR DESCRIPTION
## Summary
- validate and sanitize contact form fields on the server
- require `TO_EMAIL` environment variable instead of default recipient
- add `validator` dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bff7b4fb2083258c62cf1c6f5ce177