### PR TITLE
refactor: hoist constant data to module scope

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { motion } from 'framer-motion';
 import { Target, Users, Award, TrendingUp } from 'lucide-react';
 
-const About = () => {
-  const stats = [
+export const stats = [
     {
       icon: Users,
       value: '500+',
@@ -24,8 +23,9 @@ const About = () => {
       value: '24/7',
       label: 'System Availability'
     }
-  ];
+];
 
+const About = () => {
   return (
     <section id="about" className="py-20 px-6">
       <div className="container mx-auto">

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -6,6 +6,21 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/components/ui/use-toast';
 
+export const contactInfo = [
+    {
+      icon: Mail,
+      title: 'Email Us',
+      content: 'contact@mediflow.io',
+      description: 'Send us an email anytime'
+    },
+    {
+      icon: Phone,
+      title: 'Call Us',
+      content: '+972 53-5236450',
+      description: 'we will get back to you within 24 hours'
+    }
+];
+
 const Contact = () => {
   const [formData, setFormData] = useState({
     name: '',
@@ -58,21 +73,6 @@ const Contact = () => {
       setIsSubmitting(false);
     }
   };
-
-  const contactInfo = [
-    {
-      icon: Mail,
-      title: 'Email Us',
-      content: 'contact@mediflow.io',
-      description: 'Send us an email anytime'
-    },
-    {
-      icon: Phone,
-      title: 'Call Us',
-      content: '+972 53-5236450',
-      description: 'we will get back to you within 24 hours'
-    }
-  ];
 
   return (
     <section id="contact" className="py-20 px-6">

--- a/src/components/Solutions.jsx
+++ b/src/components/Solutions.jsx
@@ -5,10 +5,7 @@ import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 import { toast } from '@/components/ui/use-toast';
 
-const Solutions = () => {
-  const navigate = useNavigate();
-  
-  const solutions = [
+export const solutions = [
     {
       icon: Database,
       title: 'Medical Data Organization',
@@ -51,7 +48,10 @@ const Solutions = () => {
       features: ['Team collaboration', 'Secure messaging', 'Shared insights', 'Care coordination'],
       route: '/solutions/collaborative-platform'
     }
-  ];
+];
+
+const Solutions = () => {
+  const navigate = useNavigate();
 
   const handleLearnMore = (solution) => {
     if (solution.route) {

--- a/src/pages/solutions/AIClinicalDecisionSupport.jsx
+++ b/src/pages/solutions/AIClinicalDecisionSupport.jsx
@@ -4,10 +4,7 @@ import { Brain, ArrowLeft, CheckCircle, TrendingUp, Shield, Target } from 'lucid
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 
-const AIClinicalDecisionSupport = () => {
-  const navigate = useNavigate();
-
-  const features = [
+export const features = [
     {
       icon: Brain,
       title: 'Predictive Analytics',
@@ -28,16 +25,19 @@ const AIClinicalDecisionSupport = () => {
       title: 'Outcome Prediction',
       description: 'AI models predict treatment outcomes and recovery timelines, helping clinicians set realistic expectations and optimize care plans.'
     }
-  ];
+];
 
-  const benefits = [
+export const benefits = [
     'Improve diagnostic accuracy by 40%',
     'Reduce medical errors by 60%',
     'Enhance patient outcomes',
     'Optimize treatment protocols',
     'Enable early intervention',
     'Support evidence-based decisions'
-  ];
+];
+
+const AIClinicalDecisionSupport = () => {
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-green-50">

--- a/src/pages/solutions/AdvancedAnalyticsPlatform.jsx
+++ b/src/pages/solutions/AdvancedAnalyticsPlatform.jsx
@@ -4,10 +4,7 @@ import { BarChart3, ArrowLeft, CheckCircle, TrendingUp, PieChart, Activity } fro
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 
-const AdvancedAnalyticsPlatform = () => {
-  const navigate = useNavigate();
-
-  const features = [
+export const features = [
     {
       icon: BarChart3,
       title: 'Custom Dashboards',
@@ -28,16 +25,19 @@ const AdvancedAnalyticsPlatform = () => {
       title: 'Performance Metrics',
       description: 'Track key performance indicators and operational efficiency metrics with automated alerts and benchmarking capabilities.'
     }
-  ];
+];
 
-  const benefits = [
+export const benefits = [
     'Make data-driven decisions',
     'Identify operational inefficiencies',
     'Track patient outcome trends',
     'Optimize resource allocation',
     'Monitor compliance metrics',
     'Improve financial performance'
-  ];
+];
+
+const AdvancedAnalyticsPlatform = () => {
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-green-50">

--- a/src/pages/solutions/CollaborativePlatform.jsx
+++ b/src/pages/solutions/CollaborativePlatform.jsx
@@ -4,10 +4,7 @@ import { Users, ArrowLeft, CheckCircle, MessageSquare, Share2, Calendar } from '
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 
-const CollaborativePlatform = () => {
-  const navigate = useNavigate();
-
-  const features = [
+export const features = [
     {
       icon: Users,
       title: 'Team Collaboration',
@@ -28,16 +25,19 @@ const CollaborativePlatform = () => {
       title: 'Care Coordination',
       description: 'Integrated care coordination tools help manage patient transitions, appointments, and multi-disciplinary treatment plans.'
     }
-  ];
+];
 
-  const benefits = [
+export const benefits = [
     'Improve care coordination',
     'Enhance team communication',
     'Reduce care gaps',
     'Streamline patient transitions',
     'Share best practices',
     'Increase patient satisfaction'
-  ];
+];
+
+const CollaborativePlatform = () => {
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-green-50">

--- a/src/pages/solutions/MedicalDataOrganization.jsx
+++ b/src/pages/solutions/MedicalDataOrganization.jsx
@@ -4,10 +4,7 @@ import { Database, ArrowLeft, CheckCircle, BarChart3, Shield, Zap } from 'lucide
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 
-const MedicalDataOrganization = () => {
-  const navigate = useNavigate();
-
-  const features = [
+export const features = [
     {
       icon: Database,
       title: 'Automated Data Extraction',
@@ -28,16 +25,19 @@ const MedicalDataOrganization = () => {
       title: 'HIPAA Compliance',
       description: 'Built-in compliance features ensure all data handling meets healthcare regulations and security standards.'
     }
-  ];
+];
 
-  const benefits = [
+export const benefits = [
     'Reduce data entry time by 80%',
     'Improve data accuracy by 95%',
     'Enable instant data retrieval',
     'Ensure regulatory compliance',
     'Streamline clinical workflows',
     'Enhance patient care quality'
-  ];
+];
+
+const MedicalDataOrganization = () => {
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-green-50">

--- a/src/pages/solutions/SecureDataManagement.jsx
+++ b/src/pages/solutions/SecureDataManagement.jsx
@@ -4,10 +4,7 @@ import { Shield, ArrowLeft, CheckCircle, Lock, Eye, FileCheck } from 'lucide-rea
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 
-const SecureDataManagement = () => {
-  const navigate = useNavigate();
-
-  const features = [
+export const features = [
     {
       icon: Lock,
       title: 'End-to-End Encryption',
@@ -28,16 +25,19 @@ const SecureDataManagement = () => {
       title: 'Compliance Monitoring',
       description: 'Automated compliance monitoring ensures adherence to HIPAA, GDPR, and other healthcare regulations with real-time alerts and reporting.'
     }
-  ];
+];
 
-  const benefits = [
+export const benefits = [
     'Protect patient privacy',
     'Meet regulatory requirements',
     'Prevent data breaches',
     'Ensure data integrity',
     'Enable secure collaboration',
     'Maintain audit compliance'
-  ];
+];
+
+const SecureDataManagement = () => {
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-green-50">

--- a/src/pages/solutions/WorkflowAutomation.jsx
+++ b/src/pages/solutions/WorkflowAutomation.jsx
@@ -4,10 +4,7 @@ import { Zap, ArrowLeft, CheckCircle, Settings, Clock, Bell } from 'lucide-react
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
 
-const WorkflowAutomation = () => {
-  const navigate = useNavigate();
-
-  const features = [
+export const features = [
     {
       icon: Settings,
       title: 'Process Automation',
@@ -28,16 +25,19 @@ const WorkflowAutomation = () => {
       title: 'Integration APIs',
       description: 'Seamless integration with existing healthcare systems and third-party applications through robust API connections and data synchronization.'
     }
-  ];
+];
 
-  const benefits = [
+export const benefits = [
     'Reduce manual tasks by 70%',
     'Eliminate workflow bottlenecks',
     'Improve operational efficiency',
     'Minimize human errors',
     'Optimize resource utilization',
     'Enhance staff productivity'
-  ];
+];
+
+const WorkflowAutomation = () => {
+  const navigate = useNavigate();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 via-blue-50 to-green-50">


### PR DESCRIPTION
## Summary
- export `solutions`, `stats`, and `contactInfo` at module scope to reuse and avoid re-creation
- move feature/benefit arrays for each solution page to module scope for easier testing and reduced re-rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c03358f4fc832596d32f3b7da45f36