### PR TITLE
feat: add rate limiting and captcha validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A modern, responsive healthcare technology website built with React, Vite, and T
 - **Responsive Design**: Optimized for all devices
 - **Modern UI**: Built with Tailwind CSS and Framer Motion animations
 - **Contact Form**: Integrated email functionality via Vercel serverless functions
+- **Spam Protection**: Rate limiting and optional CAPTCHA verification
 - **Solution Pages**: Dedicated pages for each healthcare solution
 - **SEO Optimized**: React Helmet for meta tags and SEO
 
@@ -88,6 +89,7 @@ For production (Vercel), set these environment variables:
 - `GMAIL_USER`: Your Gmail address
 - `GMAIL_APP_PASSWORD`: Your Gmail App Password (16 characters)
 - `TO_EMAIL`: Email address to receive contact form submissions
+- `RECAPTCHA_SECRET` or `HCAPTCHA_SECRET` (optional): CAPTCHA verification secrets
 
 ## 🚀 Deployment
 

--- a/env.example
+++ b/env.example
@@ -5,3 +5,8 @@ TO_EMAIL=your-recipient@gmail.com
 
 # Note: For production, these variables should be set in Vercel dashboard
 # See GMAIL_SETUP.md for detailed setup instructions
+
+# CAPTCHA verification (optional)
+# Provide either RECAPTCHA_SECRET or HCAPTCHA_SECRET
+RECAPTCHA_SECRET=your-recaptcha-secret
+HCAPTCHA_SECRET=your-hcaptcha-secret


### PR DESCRIPTION
## Summary
- add in-memory request throttling for email API
- verify optional reCAPTCHA or hCaptcha token before sending mail
- document CAPTCHA secrets in env template and README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c03345b6208325bc3732083fad3078